### PR TITLE
use LuaJIT’s FFI to set pixel data if possible

### DIFF
--- a/love/filebrowser.lua
+++ b/love/filebrowser.lua
@@ -26,7 +26,7 @@ filebrowser.load_file = function()
 end
 
 filebrowser.init = function(gameboy)
-  filebrowser.image_data = love.image.newImageData(160, 144)
+  filebrowser.image_data = love.image.newImageData(256, 256)
   if ffi_status then
     filebrowser.raw_image_data = ffi.cast("luaGB_pixel*", filebrowser.image_data:getPointer())
   end
@@ -323,18 +323,21 @@ filebrowser.draw = function(dx, dy, scale)
   filebrowser.draw_image(22, 0, filebrowser.logo)
 
   -- Blit the virtual game screen to a love canvas
-  local width = 160
-  for x = 0, (width - 1) do
-    for y = 0, 143 do
-      if filebrowser.raw_image_data then
-        local pixel = filebrowser.raw_image_data[y*width+x]
-        local v_pixel = filebrowser.game_screen[y][x]
+  local pixels = filebrowser.game_screen
+  local image_data = filebrowser.image_data
+  local raw_image_data = filebrowser.raw_image_data
+  local stride = image_data:getWidth()
+  for y = 0, 143 do
+    for x = 0, 159 do
+      if raw_image_data then
+        local pixel = raw_image_data[y*stride+x]
+        local v_pixel = pixels[y][x]
         pixel.r = v_pixel[1]
         pixel.g = v_pixel[2]
         pixel.b = v_pixel[3]
         pixel.a = 255
       else
-        filebrowser.image_data:setPixel(x, y, unpack(filebrowser.game_screen[y][x]))
+        image_data:setPixel(x, y, pixels[y][x][1], pixels[y][x][2], pixels[y][x][3], 255)
       end
     end
   end

--- a/love/main.lua
+++ b/love/main.lua
@@ -207,7 +207,7 @@ function love.load(args)
   local small_font = love.graphics.newImageFont("images/5x3font_bm.png", "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~ ", 1)
   love.graphics.setFont(small_font)
 
-  LuaGB.game_screen_imagedata = love.image.newImageData(160, 144)
+  LuaGB.game_screen_imagedata = love.image.newImageData(256, 256)
   if ffi_status then
     LuaGB.raw_game_screen_imagedata = ffi.cast("luaGB_pixel*", LuaGB.game_screen_imagedata:getPointer())
   end

--- a/love/main.lua
+++ b/love/main.lua
@@ -269,18 +269,21 @@ function LuaGB:print_instructions()
 end
 
 function LuaGB:draw_game_screen(dx, dy, scale)
-  local width = 160
+  local pixels = self.gameboy.graphics.game_screen
+  local image_data = self.game_screen_imagedata
+  local raw_image_data = self.raw_game_screen_imagedata
+  local stride = image_data:getWidth()
   for y = 0, 143 do
-    for x = 0, (width - 1) do
-      if self.raw_game_screen_imagedata then
-        local pixel = self.raw_game_screen_imagedata[y*width+x]
-        local v_pixel = self.gameboy.graphics.game_screen[y][x]
+    for x = 0, 159 do
+      if raw_image_data then
+        local pixel = raw_image_data[y*stride+x]
+        local v_pixel = pixels[y][x]
         pixel.r = v_pixel[1]
         pixel.g = v_pixel[2]
         pixel.b = v_pixel[3]
         pixel.a = 255
       else
-        self.game_screen_imagedata:setPixel(x, y, self.gameboy.graphics.game_screen[y][x][1], self.gameboy.graphics.game_screen[y][x][2], self.gameboy.graphics.game_screen[y][x][3], 255)
+        image_data:setPixel(x, y, pixels[y][x][1], pixels[y][x][2], pixels[y][x][3], 255)
       end
     end
   end

--- a/love/main.lua
+++ b/love/main.lua
@@ -39,7 +39,6 @@ LuaGB.screen_scale = 3
 local ffi_status, ffi
 if type(jit) == "table" and jit.status() then
   ffi_status, ffi = pcall(require, "ffi")
-  print('ffi_status', ffi_status)
   if ffi_status then
     ffi.cdef("typedef struct { unsigned char r, g, b, a; } luaGB_pixel;")
   end


### PR DESCRIPTION
By checking to see if we have access to the FFI and using that to set pixel data directly, we seem a large speed up in one of the main bottlenecks.

This will fallback to using the ImageData:setPixel API on platforms that do not have access to the FFI.

In Lua5.1, without the FFI, the Pokemon Yellow opening sequence runs at ~20FPS on my machine. With these changes, using LuaJIT's FFI, it runs at pretty close to 60FPS and the audio tearing is markedly decreased.