### PR TITLE
Correctly initialize sub_y position across tile and scanline boundaries

### DIFF
--- a/gameboy/graphics/init.lua
+++ b/gameboy/graphics/init.lua
@@ -418,6 +418,11 @@ function Graphics.new(modules)
       scanline_data.active_attr = scanline_data.current_map_attr[scanline_data.bg_tile_x][scanline_data.bg_tile_y]
       scanline_data.active_tile = scanline_data.current_map[scanline_data.bg_tile_x][scanline_data.bg_tile_y]
       scanline_data.window_active = true
+
+      local tile_attr = scanline_data.current_map_attr[scanline_data.bg_tile_x][scanline_data.bg_tile_y]
+      if tile_attr.vertical_flip then
+        scanline_data.sub_y = 7 - scanline_data.sub_y
+      end
     end
   end
 

--- a/gameboy/graphics/init.lua
+++ b/gameboy/graphics/init.lua
@@ -462,6 +462,10 @@ function Graphics.new(modules)
           if scanline_data.bg_tile_y >= 32 then
             scanline_data.bg_tile_y = scanline_data.bg_tile_y - 32
           end
+        else
+          -- The window is active; reset just our sub_y so the below tile_flip logic works
+          -- correctly
+          scanline_data.sub_y = (frame_data.window_draw_y - 1) % 8
         end
 
         local tile_attr = scanline_data.current_map_attr[scanline_data.bg_tile_x][scanline_data.bg_tile_y]

--- a/gameboy/graphics/init.lua
+++ b/gameboy/graphics/init.lua
@@ -392,6 +392,11 @@ function Graphics.new(modules)
     scanline_data.active_attr = scanline_data.current_map_attr[scanline_data.bg_tile_x][scanline_data.bg_tile_y]
     scanline_data.active_tile = scanline_data.current_map[scanline_data.bg_tile_x][scanline_data.bg_tile_y]
     scanline_data.window_active = false
+
+    local tile_attr = scanline_data.current_map_attr[scanline_data.bg_tile_x][scanline_data.bg_tile_y]
+    if tile_attr.vertical_flip then
+      scanline_data.sub_y = 7 - scanline_data.sub_y
+    end
   end
 
   graphics.switch_to_window = function()


### PR DESCRIPTION
There were two separate problems contributing to flipped tile weirdness:

1. The sub_y position wasn't respecting the attribute layer at the start of the scanline. Tiles at the far left of the screen would often be flipped incorrectly as a result
2. The sub_y position was never reset across tile boundaries when the window was active. Honestly I'm surprised this caused so few issues; games don't seem to rely on flipped tiles in their status areas very often.

Both of these issues are now squashed, and I haven't observed any regressions.

Fixes #15 