### PR TITLE
Fix stale palette references at startup

### DIFF
--- a/gameboy/graphics/init.lua
+++ b/gameboy/graphics/init.lua
@@ -114,8 +114,9 @@ function Graphics.new(modules)
   end
 
   graphics.reset = function()
-    graphics.cache.reset()
+    -- Cache keeps references to the palette values so reset order is important
     graphics.palette.reset()
+    graphics.cache.reset()
 
     -- zero out all of VRAM:
     for i = 0x8000, (0x8000 + (16 * 2 * 1024) - 1) do


### PR DESCRIPTION
Fix stale palette references at startup.

Doesn't affect most games because they write to the attributes, Tuff is impacted by this because it's practically a DMG game that only uses a few GBC features. Since the game doesn't write to the attributes, the cache never fetches the palette references that are being updated.

*Tuff: https://github.com/BonsaiDen/Tuff.gb

Before:

![20230923_01h14m12s_grim](https://github.com/zeta0134/LuaGB/assets/14349965/74583157-45f4-42b8-bde2-11adc82a5ff9)

After:

![20230923_01h14m49s_grim](https://github.com/zeta0134/LuaGB/assets/14349965/32fc9b47-c096-49fa-bb56-79fe0a40b4de)
